### PR TITLE
Add a method to get Auth token to OneDrive service

### DIFF
--- a/backend/internal/onedrive/models.go
+++ b/backend/internal/onedrive/models.go
@@ -18,3 +18,7 @@ type DriveItem struct {
 type FolderContentsResponse struct {
 	Value []DriveItem `json:"value"`
 }
+
+type AuthTokenResponse struct {
+	AuthToken string `json:"access_token"`
+}

--- a/backend/internal/onedrive/service.go
+++ b/backend/internal/onedrive/service.go
@@ -11,17 +11,30 @@ import (
 
 const (
 	ImageMimeTypePrefix = "image/"
+	DefaultScope        = "https://graph.microsoft.com/.default"
 )
+
+type ServiceConfig struct {
+	BaseUrl      string
+	ClientId     string
+	ClientSecret string
+	RedirectUri  string
+}
 
 type Service struct {
 	client        *http.Client
 	sharesBaseUrl string
+	client *http.Client
+	config ServiceConfig
 }
 
 func NewService(client *http.Client, sharesBaseUrl string) *Service {
+func NewService(client *http.Client, config ServiceConfig) *Service {
 	return &Service{
 		client:        client,
 		sharesBaseUrl: sharesBaseUrl,
+		client: client,
+		config: config,
 	}
 }
 
@@ -59,6 +72,7 @@ func (s *Service) getItemsFromOneDrive(folderLink, authToken string) ([]DriveIte
 	if err != nil {
 		return nil, errors.New("failed to send request")
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("received non-200 response code")

--- a/backend/internal/onedrive/service.go
+++ b/backend/internal/onedrive/service.go
@@ -11,34 +11,37 @@ import (
 
 const (
 	ImageMimeTypePrefix = "image/"
-	DefaultScope        = "https://graph.microsoft.com/.default"
+	FilesReadScope      = "files.read"
+	AuthCodeGrantType   = "authorization_code"
 )
 
 type ServiceConfig struct {
-	BaseUrl      string
+	SharesBaseUrl string
+	AuthTokenUrl  string
+
 	ClientId     string
 	ClientSecret string
 	RedirectUri  string
 }
 
 type Service struct {
-	client        *http.Client
-	sharesBaseUrl string
 	client *http.Client
 	config ServiceConfig
 }
 
-func NewService(client *http.Client, sharesBaseUrl string) *Service {
 func NewService(client *http.Client, config ServiceConfig) *Service {
 	return &Service{
-		client:        client,
-		sharesBaseUrl: sharesBaseUrl,
 		client: client,
 		config: config,
 	}
 }
 
-func (s *Service) GetImagesFromSharedFolder(folderLink, authToken string) ([]DriveImage, error) {
+func (s *Service) GetImagesFromSharedFolder(folderLink, authCode string) ([]DriveImage, error) {
+	authToken, err := s.getUserDelegatedToken(authCode)
+	if err != nil {
+		return nil, err
+	}
+
 	driveItems, err := s.getItemsFromOneDrive(folderLink, authToken)
 	if err != nil {
 		return nil, err
@@ -57,9 +60,49 @@ func (s *Service) GetImagesFromSharedFolder(folderLink, authToken string) ([]Dri
 	return images, nil
 }
 
+func (s *Service) getUserDelegatedToken(authCode string) (string, error) {
+	requestUrl := s.config.AuthTokenUrl
+	req, err := http.NewRequest(http.MethodPost, requestUrl, nil)
+	if err != nil {
+		return "", errors.New("failed to create request")
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	query := req.URL.Query()
+	query.Add("client_id", s.config.ClientId)
+	query.Add("client_secret", s.config.ClientSecret)
+	query.Add("scope", FilesReadScope)
+	query.Add("grant_type", AuthCodeGrantType)
+	query.Add("code", authCode)
+	query.Add("redirect_uri", s.config.RedirectUri)
+	req.URL.RawQuery = query.Encode()
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", errors.New("failed to send request")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New("received non-200 response code")
+	}
+
+	var response AuthTokenResponse
+	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return "", errors.New("failed to decode response")
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return "", errors.New("failed to close response body")
+	}
+
+	return response.AuthToken, nil
+}
+
 func (s *Service) getItemsFromOneDrive(folderLink, authToken string) ([]DriveItem, error) {
 	encodedFolderLink := encodeFolderLink(folderLink)
-	requestUrl := fmt.Sprintf("%s/%s/driveItem", s.sharesBaseUrl, encodedFolderLink)
+	requestUrl := fmt.Sprintf("%s/%s/driveItem", s.config.SharesBaseUrl, encodedFolderLink)
 
 	req, err := http.NewRequest(http.MethodGet, requestUrl, nil)
 	if err != nil {
@@ -72,14 +115,13 @@ func (s *Service) getItemsFromOneDrive(folderLink, authToken string) ([]DriveIte
 	if err != nil {
 		return nil, errors.New("failed to send request")
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("received non-200 response code")
 	}
 
 	var response FolderContentsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, errors.New("failed to decode response")
 	}
 

--- a/backend/internal/onedrive/service_test.go
+++ b/backend/internal/onedrive/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,22 +99,16 @@ func TestGetImagesFromSharedFolder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(
-				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(tt.mockStatusCode)
-					if tt.mockResponse == nil {
-						return
-					}
-
-					err := json.NewEncoder(w).Encode(tt.mockResponse)
-					if err != nil {
-						t.Fatalf("failed to encode response: %v", err)
-					}
-				}))
+			server := initMockServer(t, tt.mockStatusCode, tt.mockResponse)
 			defer server.Close()
 
 			client := server.Client()
-			service := NewService(client, server.URL)
+			serviceConfig := ServiceConfig{
+				SharesBaseUrl: server.URL + "/shares",
+				AuthTokenUrl:  server.URL + "/token",
+			}
+
+			service := NewService(client, serviceConfig)
 
 			items, err := service.GetImagesFromSharedFolder("encodedFolderLink", "authToken")
 
@@ -137,7 +132,7 @@ func loadMockResponseFromFile(t *testing.T, s string) interface{} {
 	}
 
 	var response interface{}
-	if err := json.NewDecoder(file).Decode(&response); err != nil {
+	if err = json.NewDecoder(file).Decode(&response); err != nil {
 		t.Fatalf("failed to decode file: %v", err)
 	}
 
@@ -147,4 +142,27 @@ func loadMockResponseFromFile(t *testing.T, s string) interface{} {
 	}
 
 	return response
+}
+
+func initMockServer(t *testing.T, mockStatusCode int, mockSharesResponse interface{}) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(mockStatusCode)
+			if r.URL.Path == "/token" {
+				err := json.NewEncoder(w).Encode(AuthTokenResponse{AuthToken: "authToken"})
+				if err != nil {
+					t.Fatalf("failed to encode auth response: %v", err)
+				}
+
+			} else if strings.Contains(r.URL.Path, "/shares") {
+				if mockSharesResponse != nil {
+					err := json.NewEncoder(w).Encode(mockSharesResponse)
+					if err != nil {
+						t.Fatalf("failed to encode shares response: %v", err)
+					}
+				}
+			}
+		}))
+
+	return server
 }


### PR DESCRIPTION
OneDrive service will need to gen an auth token to make requests, this PR implements the method.

In the future it's possible we will want to cache these tokens while they're valid, but we'll cross that bridge when we get to it.